### PR TITLE
adjust connection pool params

### DIFF
--- a/src/jdbcrunner/Manager.java
+++ b/src/jdbcrunner/Manager.java
@@ -369,7 +369,22 @@ public class Manager {
 		dataSource.setDefaultAutoCommit(config.isAutoCommit());
 		dataSource.setInitialSize(config.getConnPoolSize());
 		dataSource.setMaxTotal(config.getConnPoolSize());
+
+		// for tidb scale-in-out
 		dataSource.setMaxConnLifetimeMillis(config.getConnLifeTime());
+		dataSource.setLogExpiredConnections(false); // skip logging expired connections
+		
+		// setValidationQuery when using oracle or tidb/mysql/postgresql
+		if (config.getJdbcUrl().contains("oracle")) {
+			dataSource.setValidationQuery("select 1 from dual");
+		} else {
+			dataSource.setValidationQuery("select 1");
+		}
+		dataSource.setValidationQueryTimeout(1); // set timeout to 1 second
+		dataSource.setTestOnBorrow(true); // validate connections on borrow
+		dataSource.setTestOnReturn(true); // validate connections on return
+		dataSource.setAutoCommitOnReturn(false); // do not auto-commit on return
+		dataSource.setRollbackOnReturn(false); // do not rollback on return
 
 		// MaxIdleはデフォルト値が8。無制限に変更する
 		dataSource.setMaxIdle(DATASOURCE_NO_LIMIT);


### PR DESCRIPTION
* setLogExpiredConnections : 
  * MaxConnLifetime になるタイミングに大量に出るWarningをOFFにする
* setValidationQuery / setValidationQueryTimeout / setTestOnBorrow / setTestOnReturn
  * ValidationQuery を使う
* setAutoCommitOnReturn / setRollbackOnReturn
  * `connection.Close` の時に 接続が既に切れる場合に set AutoCommit や Rollback を実行するとエラーになるため、 false にする

```
		// for tidb scale-in-out
		dataSource.setMaxConnLifetimeMillis(config.getConnLifeTime());
		dataSource.setLogExpiredConnections(false); // skip logging expired connections
		
		// setValidationQuery when using oracle or tidb/mysql/postgresql
		if (config.getJdbcUrl().contains("oracle")) {
			dataSource.setValidationQuery("select 1 from dual");
		} else {
			dataSource.setValidationQuery("select 1");
		}
		dataSource.setValidationQueryTimeout(1); // set timeout to 1 second
		dataSource.setTestOnBorrow(true); // validate connections on borrow
		dataSource.setTestOnReturn(true); // validate connections on return
		dataSource.setAutoCommitOnReturn(false); // do not auto-commit on return
		dataSource.setRollbackOnReturn(false); // do not rollback on return
```